### PR TITLE
Add support for preventing a container escape vulnerability

### DIFF
--- a/sources/vbh_events.c
+++ b/sources/vbh_events.c
@@ -37,6 +37,13 @@ int hvi_handle_event_msr(__u32 msr, __u64 old_value,
 		sizeof(struct hvi_event_msr), allow);
 }
 
+int hvi_handle_event_dfo(int *params)
+{
+	int allow;
+
+	return hvi_report_event(vmcall, params, sizeof(int *), &allow);
+}
+
 int hvi_handle_event_vmcall(void)
 {
 	int allow;

--- a/sources/vbh_rt.c
+++ b/sources/vbh_rt.c
@@ -181,6 +181,9 @@ void handle_vmcall(struct vcpu_vmx *vcpu)
 	case VCPU_REQUEST_HYPERCALL:
 		handle_vcpu_request_hypercall(vcpu, params);
 		break;
+	case DFO_HYPERCALL:
+		hvi_handle_event_dfo((int *)params);
+		break;
 	default:
 		hvi_handle_event_vmcall();
 		break;

--- a/sources/vmx_common.h
+++ b/sources/vmx_common.h
@@ -22,6 +22,7 @@ typedef enum
 }msr_reg_e;
 
 #define KERNEL_HARDENING_HYPERCALL  40
+#define DFO_HYPERCALL				42
 #define VCPU_REQUEST_HYPERCALL		60
 
 typedef enum {
@@ -293,6 +294,7 @@ extern void handle_write_msr(struct vcpu_vmx *vcpu);
 extern int hvi_handle_event_cr(__u16 cr, unsigned long old_value, unsigned long new_value, int* allow);
 extern int hvi_handle_event_msr(__u32 msr, __u64 old_value, __u64 new_value, int* allow);
 extern int hvi_handle_event_vmcall(void);
+extern int hvi_handle_event_dfo(int *params);
 
 extern void dump_entries(u64 gpa);
 extern void handle_kernel_hardening_hypercall(u64 params);


### PR DESCRIPTION
This allows hooking the `do_filp_open` function to detect attempts to
overwrite the docker runc.

More info on `CVE-2019-5736`:
https://kubernetes.io/blog/2019/02/11/runc-and-cve-2019-5736/

The code that would use this feature is here: https://github.com/bitdefender/vbh_sample/commit/fc2774a3a960a0b99c932e449480c6b43263649d

Signed-off-by: Alexandru-Ciprian Cihodaru <acihodaru@bitdefender.com>
Signed-off-by: Adrian Pop <apop@bitdefender.com>